### PR TITLE
Fix documentation deployment

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,8 +9,6 @@ makedocs(;
     sitename = "PerfChecker.jl",
     format = DocumenterVitepress.MarkdownVitepress(
         repo = "https://github.com/JuliaConstraints/PerfChecker.jl",
-        devurl = "dev",
-        deploy_url = "JuliaConstraints.github.io/PerfChecker.jl"
     ),
     pages = [
         "Home" => "index.md"


### PR DESCRIPTION
This PR lets deploy_url and devurl be automatic.  You don't actually need these if going for the default, and in general they should be full URLs (with HTTPS:// prefixed)